### PR TITLE
Add val parameter to set in Typescript file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 export function get (object: object, path: string|string[], def?: any): any;
-export function set (object: object, path: string|string[]): any;
+export function set (object: object, path: string|string[], val: any): any;


### PR DESCRIPTION
The Typescript file was missing the `val` parameter for the `set` function.