### PR TITLE
Due to wrong regex shvl is still vulnerable to prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ export function get (object, path, def) {
 };
 
 export function set  (object, path, val, obj) {
-  return !/^(__proto__|constructor|prototype)$/.test(path) && ((path = path.split ? path.split('.') : path.slice(0)).slice(0, -1).reduce(function (obj, p) {
+  return !/(__proto__|constructor|prototype)/.test(path) && ((path = path.split ? path.split('.') : path.slice(0)).slice(0, -1).reduce(function (obj, p) {
     return obj[p] = obj[p] || {};
   }, obj = object)[path.pop()] = val), object;
 };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-export function get (object, path, def) {
+export function get(object, path, def) {
   return (object = (path.split ? path.split('.') : path).reduce(function (obj, p) {
     return obj && obj[p]
   }, object)) === undefined ? def : object;
 };
 
 export function set  (object, path, val, obj) {
-  return !/(__proto__|constructor|prototype)/.test(path) && ((path = path.split ? path.split('.') : path.slice(0)).slice(0, -1).reduce(function (obj, p) {
-    return obj[p] = obj[p] || {};
+  return ((path = path.split ? path.split('.') : path.slice(0)).slice(0, -1).reduce(function (obj, p) {
+    return (!/^(__proto__|constructor|prototype)$/.test(p))? obj[p] = obj[p] || {} : {};
   }, obj = object)[path.pop()] = val), object;
 };

--- a/test.js
+++ b/test.js
@@ -73,6 +73,8 @@ cases('set({}, key, value)', ({ obj, key, value, expected }) => {
   "set(obj, 'a.b.c', 'bar')": { key: 'a.b.c', value: 'bar', expected: { a: { b: { c: 'bar' } } }, obj: { a: { b: { c: 'foo' } } } },
   "set(obj, 'a.b', 'foo')": { key: 'a.b', value: 'foo', expected: { a: { b: 'foo' } }, obj: { a: { b: undefined } } },
   "set(obj, 'a.b', undefined)": { key: 'a.b', value: undefined, expected: { a: { b: undefined } }, obj: { a: { b: 'foo' } } },
+  "set(obj, '___proto___.a', 'foo')": { key: '___proto___.a', value: 'foo', expected: { ___proto___: { a: 'foo' } } },
+  "set(obj, 'a.constructorx.b', 'foo')": { key: 'a.constructorx.b', value: 'foo', expected: { a: { constructorx: { b: 'foo' } } } },
 });
 
 // prevent prototype pollution

--- a/test.js
+++ b/test.js
@@ -73,12 +73,17 @@ cases('set({}, key, value)', ({ obj, key, value, expected }) => {
   "set(obj, 'a.b.c', 'bar')": { key: 'a.b.c', value: 'bar', expected: { a: { b: { c: 'bar' } } }, obj: { a: { b: { c: 'foo' } } } },
   "set(obj, 'a.b', 'foo')": { key: 'a.b', value: 'foo', expected: { a: { b: 'foo' } }, obj: { a: { b: undefined } } },
   "set(obj, 'a.b', undefined)": { key: 'a.b', value: undefined, expected: { a: { b: undefined } }, obj: { a: { b: 'foo' } } },
-  "set(obj, '__proto__', 'foo')": { key: "__proto__", value: "foo", expected: {} },
-  "set(obj, 'a.__proto__', 'foo')": { key: "__proto__", value: "foo", expected: { a: undefined } },  
-  "set(obj, 'constructor', 'foo')": { key: "constructor", value: "foo", expected: {} },
-  "set(obj, 'a.constructor', 'foo')": { key: "constructor", value: "foo", expected: { a: undefined } },
-  "set(obj, 'prototype', 'foo')": { key: "prototype", value: "foo", expected: {} },
-  "set(obj, 'a.prototype', 'foo')": { key: "prototype", value: "foo", expected: { a: undefined } },
+});
+
+// prevent prototype pollution
+cases('get(Object, key)', ({ key, value, test }) => {
+  shvl.set({}, key, value);
+  expect(shvl.get(Object, test || key)).toEqual(undefined);
+}, {
+  "set({}, '__proto__.b', 'foo')": { key: '__proto__.b', value: 'foo' },
+  "set({}, 'a.__proto__.b', 'foo')": { key: 'a.__proto__.b', value: 'foo' },
+  "set({}, 'constructor.prototype.b', 'foo')": { key: 'constructor.prototype.b', value: 'foo'},
+  "set({}, 'a.constructor.prototype.b', 'foo')": { key: 'a.constructor.prototype.b', value: 'foo'}
 });
 
 cases('set(undefined, key, value)', ({ obj, key, value }) => {


### PR DESCRIPTION
As I reported here: https://www.huntr.dev/bounties/2-other-robinvdvleuten/shvl/, shvl is still vulnerable to prototype pollution. I believe that changing `!/^(__proto__|constructor|prototype)$/` to `!/(__proto__|constructor|prototype)/` is enough to solve the problem but i prefer to keep it open to discussion